### PR TITLE
M1 Mac environment support

### DIFF
--- a/build/ios-common.sh
+++ b/build/ios-common.sh
@@ -112,6 +112,7 @@ get_arch_name() {
         4) echo "i386" ;;
         5) echo "x86-64" ;;
         6) echo "x86-64-mac-catalyst" ;;
+        7) echo "arm64-simulator" ;;
     esac
 }
 
@@ -146,7 +147,7 @@ get_target_build_directory() {
 
 get_target_arch() {
     case ${ARCH} in
-        arm64 | arm64e)
+        arm64 | arm64e | arm64-simulator)
             echo "aarch64"
         ;;
         x86-64 | x86-64-mac-catalyst)
@@ -167,7 +168,7 @@ get_sdk_name() {
         armv7 | armv7s | arm64 | arm64e)
             echo "iphoneos"
         ;;
-        i386 | x86-64)
+        i386 | x86-64 | arm64-simulator)
             echo "iphonesimulator"
         ;;
         x86-64-mac-catalyst)
@@ -185,7 +186,7 @@ get_min_version_cflags() {
         armv7 | armv7s | arm64 | arm64e)
             echo "-miphoneos-version-min=${IOS_MIN_VERSION}"
         ;;
-        i386 | x86-64)
+        i386 | x86-64 | arm64-simulator)
             echo "-mios-simulator-version-min=${IOS_MIN_VERSION}"
         ;;
         x86-64-mac-catalyst)
@@ -206,7 +207,7 @@ get_common_cflags() {
     local BUILD_DATE="-DMOBILE_FFMPEG_BUILD_DATE=$(date +%Y%m%d 2>>${BASEDIR}/build.log)"
 
     case ${ARCH} in
-        i386 | x86-64)
+        i386 | x86-64 | arm64-simulator)
             echo "-fstrict-aliasing -DIOS ${LTS_BUILD_FLAG}${BUILD_DATE} -isysroot ${SDK_PATH}"
         ;;
         x86-64-mac-catalyst)
@@ -226,7 +227,7 @@ get_arch_specific_cflags() {
         armv7s)
             echo "-arch armv7s -target $(get_target_host) -march=armv7s -mcpu=generic -mfpu=neon -mfloat-abi=softfp -DMOBILE_FFMPEG_ARMV7S"
         ;;
-        arm64)
+        arm64 | arm64-simulator)
             echo "-arch arm64 -target $(get_target_host) -march=armv8-a+crc+crypto -mcpu=generic -DMOBILE_FFMPEG_ARM64"
         ;;
         arm64e)
@@ -251,7 +252,7 @@ get_size_optimization_cflags() {
         armv7 | armv7s | arm64 | arm64e | x86-64-mac-catalyst)
           ARCH_OPTIMIZATION="-Oz -Wno-ignored-optimization-argument"
         ;;
-        i386 | x86-64)
+        i386 | x86-64 | arm64-simulator)
           ARCH_OPTIMIZATION="-O2 -Wno-ignored-optimization-argument"
         ;;
     esac
@@ -268,7 +269,7 @@ get_size_optimization_asm_cflags() {
                 armv7 | armv7s | arm64 | arm64e | x86-64-mac-catalyst)
                     ARCH_OPTIMIZATION="-Oz"
                 ;;
-                i386 | x86-64)
+                i386 | x86-64 | arm64-simulator)
                     ARCH_OPTIMIZATION="-O2"
                 ;;
             esac
@@ -444,7 +445,7 @@ get_arch_specific_ldflags() {
         armv7s)
             echo "-arch armv7s -march=armv7s -mfpu=neon -mfloat-abi=softfp -fembed-bitcode -target $(get_target_host)"
         ;;
-        arm64)
+        arm64 | arm64-simulator)
             echo "-arch arm64 -march=armv8-a+crc+crypto -fembed-bitcode -target $(get_target_host)"
         ;;
         arm64e)
@@ -890,7 +891,7 @@ set_toolchain_clang_paths() {
                 export AS="${LOCAL_GAS_PREPROCESSOR} -arch arm -- ${CC} ${LOCAL_ASMFLAGS}"
             fi
         ;;
-        arm64 | arm64e)
+        arm64 | arm64e | arm64-simulator)
             if [ "$1" == "x265" ]; then
                 export AS="${LOCAL_GAS_PREPROCESSOR}"
                 export AS_ARGUMENTS="-arch aarch64"

--- a/build/ios-ffmpeg.sh
+++ b/build/ios-ffmpeg.sh
@@ -60,7 +60,7 @@ case ${ARCH} in
         NEON_FLAG="	--enable-neon"
         BITCODE_FLAGS="-fembed-bitcode -Wc,-fembed-bitcode"
     ;;
-    arm64)
+    arm64 | arm64-simulator)
         TARGET_CPU="armv8"
         TARGET_ARCH="aarch64"
         NEON_FLAG="	--enable-neon"

--- a/build/ios-jpeg.sh
+++ b/build/ios-jpeg.sh
@@ -41,7 +41,7 @@ export ASM_FLAGS=$(get_asmflags ${LIB_NAME})
 
 ARCH_OPTIONS=""
 case ${ARCH} in
-    armv7 | armv7s | arm64 | arm64e)
+    armv7 | armv7s | arm64 | arm64e | arm64-simulator)
         ARCH_OPTIONS="-DWITH_SIMD=1"
     ;;
     *)

--- a/build/ios-libpng.sh
+++ b/build/ios-libpng.sh
@@ -43,7 +43,7 @@ case ${ARCH} in
     x86 | x86-64 | x86-64-mac-catalyst)
         ARCH_OPTIONS+=" --enable-intel-sse=yes"
     ;;
-    armv7 | armv7s | arm64 | arm64e)
+    armv7 | armv7s | arm64 | arm64e | arm64-simulator)
         ARCH_OPTIONS+=" --enable-arm-neon=yes"
     ;;
 esac

--- a/build/ios-libvidstab.sh
+++ b/build/ios-libvidstab.sh
@@ -48,7 +48,7 @@ cd build
 
 ASM_FLAGS=""
 case ${ARCH} in
-    armv7 | armv7s | arm64 | arm64e)
+    armv7 | armv7s | arm64 | arm64e | arm64-simulator)
         ASM_FLAGS="-DSSE2_FOUND=0 -DSSE3_FOUND=0 -DSSSE3_FOUND=0 -DSSE4_1_FOUND=0"
     ;;
     *)

--- a/build/ios-libwebp.sh
+++ b/build/ios-libwebp.sh
@@ -40,7 +40,7 @@ export PKG_CONFIG_LIBDIR="${INSTALL_PKG_CONFIG_DIR}"
 
 ARCH_OPTIONS=""
 case ${ARCH} in
-    armv7 | armv7s | arm64 | arm64e)
+    armv7 | armv7s | arm64 | arm64e | arm64-simulator)
         ARCH_OPTIONS="--enable-neon --enable-neon-rtcd"
     ;;
     x86-64-mac-catalyst)

--- a/build/ios-nettle.sh
+++ b/build/ios-nettle.sh
@@ -39,7 +39,7 @@ export LDFLAGS=$(get_ldflags ${LIB_NAME})
 
 OPTIONAL_CPU_SUPPORT=""
 case ${ARCH} in
-    armv7 | armv7s | arm64 | arm64e)
+    armv7 | armv7s | arm64 | arm64e | arm64-simulator)
         OPTIONAL_CPU_SUPPORT="--enable-arm-neon"
     ;;
     i386 | x86-64 | x86-64-mac-catalyst)

--- a/ios.sh
+++ b/ios.sh
@@ -8,6 +8,7 @@ ARCH_ARM64E=3
 ARCH_I386=4
 ARCH_X86_64=5
 ARCH_X86_64_MAC_CATALYST=6
+ARCH_ARM64_SIMULATOR=7
 
 # LIBRARY INDEXES
 LIBRARY_FONTCONFIG=0
@@ -62,7 +63,8 @@ LIBRARY_LIBICONV=48
 LIBRARY_LIBUUID=49
 
 # ENABLE ARCH
-ENABLED_ARCHITECTURES=(1 1 1 1 1 1 1)
+ENABLED_ARCHITECTURES=(1 1 1 1 1 1 1 1)
+#ENABLED_ARCHITECTURES=(0 0 0 0 0 0 0 1)
 
 # ENABLE LIBRARIES
 ENABLED_LIBRARIES=(0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)
@@ -124,6 +126,7 @@ display_help() {
   echo -e "  --disable-i386\t\tdo not build i386 platform [yes]"
   echo -e "  --disable-x86-64\t\tdo not build x86-64 platform [yes]"
   echo -e "  --disable-x86-64-mac-catalyst\tdo not build x86-64-mac-catalyst platform [yes]\n"
+  echo -e "  --disable-arm64-simulator\t\tdo not build arm64-simulator platform [yes]"
 
   echo -e "Libraries:"
 
@@ -497,6 +500,9 @@ set_arch() {
   x86-64-mac-catalyst)
     ENABLED_ARCHITECTURES[ARCH_X86_64_MAC_CATALYST]=$2
     ;;
+  arm64-simulator)
+    ENABLED_ARCHITECTURES[ARCH_ARM64_SIMULATOR]=$2
+    ;;
   *)
     print_unknown_platform "$1"
     ;;
@@ -522,7 +528,7 @@ print_enabled_architectures() {
   echo -n "Architectures: "
 
   let enabled=0
-  for print_arch in {0..6}; do
+  for print_arch in {0..7}; do
     if [[ ${ENABLED_ARCHITECTURES[$print_arch]} -eq 1 ]]; then
       if [[ ${enabled} -ge 1 ]]; then
         echo -n ", "
@@ -1059,7 +1065,7 @@ done
 
 TARGET_ARCH_LIST=()
 
-for run_arch in {0..6}; do
+for run_arch in {0..7}; do
   if [[ ${ENABLED_ARCHITECTURES[$run_arch]} -eq 1 ]]; then
     export ARCH=$(get_arch_name $run_arch)
     export TARGET_SDK=$(get_target_sdk)


### PR DESCRIPTION
https://github.com/tanersener/mobile-ffmpeg/issues/597

Adding arm64-simulator and arm64-mac-catalyst targets to ios.sh build script.
Also adding support to bundle these with the x86_64 equivalents into fat binaries as this is needed to make an xcframework.
